### PR TITLE
feat: add SFTP Upload and Download functions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,43 @@
+version: "2"
+run:
+  modules-download-mode: readonly
+linters:
+  default: none
+  enable:
+    - errcheck
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - nilerr
+    - nolintlint
+    - revive
+    - staticcheck
+    - unused
+  settings:
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofumpt
+  settings:
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,25 +13,11 @@ repos:
           - id: end-of-file-fixer
           - id: trailing-whitespace
 
-    # - repo: https://github.com/tekwizely/pre-commit-golang
-    #   rev: master
-    #   hooks:
-    #       - id: go-lint
-
-    - repo: https://github.com/dnephin/pre-commit-golang
-      rev: v0.5.1
+    - repo: https://github.com/golangci/golangci-lint
+      rev: v2.12.2
       hooks:
-          - id: go-fmt
-
-          - id: go-vet
-          # - id: golangci-lint
-            # timeout is needed for CI
-            # args: [-E, gosec, -E, goconst, -E, govet, --timeout, 300s]
-          # - id: go-imports
-          # - id: go-cyclo
-          #   args: [-over=15]
-          # - id: validate-toml
-          - id: no-go-testing
+        - id: golangci-lint
+          args: ["--fix"]
     - repo: https://github.com/codespell-project/codespell
       rev: v2.4.2
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
       # Ruff version.
-      rev: v0.15.13
+      rev: v0.15.14
       hooks:
         # Run the linter.
         - id: ruff

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A project to create a new cross-platform SSH wheel for Python.
 
 1. An easy to install, multi-platform SSH wheel
 1. Personal learning about Go
-1. To explore [`gopy`](https://github.com/go-python/gopys)
+1. To explore [`gopy`](https://github.com/go-python/gopy)
 1. To explore Python packaging & compiling.  What can we
 do with available open source tooling?
 1. To explore performance characteristics
@@ -18,17 +18,17 @@ do with available open source tooling?
 
 1. Respect and give kudos to all the work that's come
 before.
-    1. In particular, the Herculian efforts of [`gopy`], [`paramiko`] and [`asyncssh`].
+    1. In particular, the Herculean efforts of [`gopy`], [`paramiko`] and [`asyncssh`].
     1. Please also be kind to all other open-source software projects you find.
 
 It is paramount that we all play nicely.  To that end, please do your very best
 not to create churn or spur conversations that may upset other developers,
-and/or cause debate without offerinig solutions.
+and/or cause debate without offering solutions.
 
 ## Build wheel
 
 The following steps should produce a wheel,
-located at `dist/ohpygossh-0.0.16-py3-none-any.whl`
+located at `dist/ohpygossh-<version>-py3-none-any.whl`
 
 ```bash
 ./make_and_validate_script.sh

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,12 @@ module gohpygossh
 
 go 1.24
 
-require golang.org/x/crypto v0.38.0
+require golang.org/x/crypto v0.41.0
 
 require github.com/larstobi/go-multipass v1.3.0
 
-require golang.org/x/sys v0.33.0 // indirect
+require (
+	github.com/kr/fs v0.1.0 // indirect
+	github.com/pkg/sftp v1.13.10 // indirect
+	golang.org/x/sys v0.35.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,17 @@
+github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
+github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/larstobi/go-multipass v1.3.0 h1:EpC0ZedJV7Os9+QNaKkPp0QdtogsVanIb1NLWYbPtWI=
 github.com/larstobi/go-multipass v1.3.0/go.mod h1:RkIg1w+XE1w+BVRVIZCPjtUWyT+p9R3Bdyn+MUkGiNg=
+github.com/pkg/sftp v1.13.10 h1:+5FbKNTe5Z9aspU88DPIKJ9z2KZoaGCu6Sr6kKR/5mU=
+github.com/pkg/sftp v1.13.10/go.mod h1:bJ1a7uDhrX/4OII+agvy28lzRvQrmIQuaHrcI1HbeGA=
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
 golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
+golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
+golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sUc=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.32.0 h1:DR4lr0TjUs3epypdhTOkMmuF5CDFJ/8pOnbzMZPQ7bg=
 golang.org/x/term v0.32.0/go.mod h1:uZG1FhGx848Sqfsq4/DlJr3xGGsYMu/L5GW4abiaEPQ=
+golang.org/x/term v0.34.0 h1:O/2T7POpk0ZZ7MAzMeWFSg6S5IpWd/RXDlM9hgM3DR4=

--- a/gohpygossh_test.go
+++ b/gohpygossh_test.go
@@ -179,13 +179,13 @@ func TestRunWithMultipass(t *testing.T) {
 	}
 
 	shortID, _ := gohpygossh.GenerateShortUUID(4)
-	dyn_vm_name := fmt.Sprintf("testvm%s", shortID)
+	dynVMName := fmt.Sprintf("testvm%s", strings.ToLower(strings.ReplaceAll(shortID, "_", "-")))
 
 	instance, err := multipass.LaunchV2(&multipass.LaunchReqV2{
 		Image:         "lts",
 		CPUS:          "2",
 		Disk:          "10g",
-		Name:          dyn_vm_name,
+		Name:          dynVMName,
 		Memory:        "3g",
 		CloudInitFile: r.CloudInitPath,
 	})
@@ -194,12 +194,12 @@ func TestRunWithMultipass(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Delete runs "multipass delete --purge", fully removing the VM when the test ends.
-	defer multipass.Delete(&multipass.DeleteRequest{Name: dyn_vm_name})
+	defer func() { _ = multipass.Delete(&multipass.DeleteRequest{Name: dynVMName}) }()
 
 	// Get the hostname of the multipass instance
 	fmt.Println(instance.IP)
 
-	info, err := multipass.Info(&multipass.InfoRequest{Name: dyn_vm_name})
+	info, err := multipass.Info(&multipass.InfoRequest{Name: dynVMName})
 	hostname := info.IP
 	if err != nil {
 		t.Fatal(err)

--- a/gohpygossh_test.go
+++ b/gohpygossh_test.go
@@ -52,14 +52,14 @@ func TestGenerateKeyPairAndCloudInit(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 }
 
-func TestGenerateKeysForSsh(t *testing.T) {
+func TestGenerateKeysForSSH(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "keys-only-test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	r, err := gohpygossh.GenerateKeysForSsh(tmpDir, "test-user")
+	r, err := gohpygossh.GenerateKeysForSSH(tmpDir, "test-user")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestPublicKeyFile(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	r, err := gohpygossh.GenerateKeysForSsh(tmpDir, "test-user")
+	r, err := gohpygossh.GenerateKeysForSSH(tmpDir, "test-user")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -38,15 +38,13 @@ func GenerateKeysForSSH(destinationDir, cloudUser string) (KeysForSSH, error) {
 	if err != nil {
 		return KeysForSSH{}, err
 	}
-
 	privateKeyFileName := temp_file.Name()
-	cmd := fmt.Sprintf("ssh-keygen -b 2048 -t rsa -q -N '' -f %s <<<y >/dev/null 2>&1", privateKeyFileName)
+	temp_file.Close()
+	os.Remove(privateKeyFileName)
 
-	output, exec_cmd_err := exec.Command("bash", "-c", cmd).Output()
-	if exec_cmd_err != nil {
-		return KeysForSSH{}, exec_cmd_err
+	if err := exec.Command("ssh-keygen", "-b", "2048", "-t", "rsa", "-q", "-N", "", "-f", privateKeyFileName).Run(); err != nil {
+		return KeysForSSH{}, err
 	}
-	fmt.Println(output)
 
 	publicKeyAbsPath, err := filepath.Abs(privateKeyFileName + ".pub")
 	if err != nil {
@@ -78,15 +76,13 @@ func GenerateKeyPairAndCloudInit(destinationDir, cloudUser string) (KeysAndInit,
 	if err != nil {
 		return KeysAndInit{}, err
 	}
-
 	privateKeyFileName := temp_file.Name()
-	cmd := fmt.Sprintf("ssh-keygen -b 2048 -t rsa -q -N '' -f %s <<<y >/dev/null 2>&1", privateKeyFileName)
+	temp_file.Close()
+	os.Remove(privateKeyFileName)
 
-	output, exec_cmd_err := exec.Command("bash", "-c", cmd).Output()
-	if exec_cmd_err != nil {
-		return KeysAndInit{}, exec_cmd_err
+	if err := exec.Command("ssh-keygen", "-b", "2048", "-t", "rsa", "-q", "-N", "", "-f", privateKeyFileName).Run(); err != nil {
+		return KeysAndInit{}, err
 	}
-	fmt.Println(output)
 
 	publicKey, err := os.ReadFile(privateKeyFileName + ".pub")
 	if err != nil {
@@ -219,6 +215,7 @@ func Upload(hostname, username, privateKey, localPath, remotePath string) error 
 
 	if _, err = io.Copy(remoteFile, localFile); err != nil {
 		remoteFile.Close()
+		_ = sftpClient.Remove(remotePath)
 		return err
 	}
 	return remoteFile.Close()
@@ -250,6 +247,7 @@ func Download(hostname, username, privateKey, remotePath, localPath string) erro
 
 	if _, err = io.Copy(localFile, remoteFile); err != nil {
 		localFile.Close()
+		_ = os.Remove(localPath)
 		return err
 	}
 	return localFile.Close()

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -16,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -201,4 +203,94 @@ func Run(hostname string, username string, privateKey string, command string) (s
 	// Finally, run the command
 	err = session.Run(command)
 	return b.String(), err
+}
+
+func Upload(hostname string, username string, privateKey string, localPath string, remotePath string) error {
+	keyBytes, err := os.ReadFile(privateKey)
+	if err != nil {
+		return err
+	}
+	signer, err := ssh.ParsePrivateKey(keyBytes)
+	if err != nil {
+		return err
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User:            username,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         time.Duration(time.Duration.Seconds(60)),
+	}
+
+	client, err := ssh.Dial("tcp", net.JoinHostPort(hostname, "22"), sshConfig)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return err
+	}
+	defer sftpClient.Close()
+
+	localFile, err := os.Open(localPath)
+	if err != nil {
+		return err
+	}
+	defer localFile.Close()
+
+	remoteFile, err := sftpClient.Create(remotePath)
+	if err != nil {
+		return err
+	}
+	defer remoteFile.Close()
+
+	_, err = io.Copy(remoteFile, localFile)
+	return err
+}
+
+func Download(hostname string, username string, privateKey string, remotePath string, localPath string) error {
+	keyBytes, err := os.ReadFile(privateKey)
+	if err != nil {
+		return err
+	}
+	signer, err := ssh.ParsePrivateKey(keyBytes)
+	if err != nil {
+		return err
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User:            username,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         time.Duration(time.Duration.Seconds(60)),
+	}
+
+	client, err := ssh.Dial("tcp", net.JoinHostPort(hostname, "22"), sshConfig)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	sftpClient, err := sftp.NewClient(client)
+	if err != nil {
+		return err
+	}
+	defer sftpClient.Close()
+
+	remoteFile, err := sftpClient.Open(remotePath)
+	if err != nil {
+		return err
+	}
+	defer remoteFile.Close()
+
+	localFile, err := os.Create(localPath)
+	if err != nil {
+		return err
+	}
+	defer localFile.Close()
+
+	_, err = io.Copy(localFile, remoteFile)
+	return err
 }

--- a/main.go
+++ b/main.go
@@ -25,18 +25,18 @@ func Hello() string {
 	return "Hello, world"
 }
 
-type KeysForSsh struct {
+type KeysForSSH struct {
 	CloudUser        string
 	PrivKeyAbsPath   string
 	PublicKeyAbsPath string
 }
 
-func GenerateKeysForSsh(destinationDir string, cloudUser string) (KeysForSsh, error) {
+func GenerateKeysForSSH(destinationDir, cloudUser string) (KeysForSSH, error) {
 	fmt.Printf("Generating keypair for user: %s", cloudUser)
 
 	temp_file, err := os.CreateTemp(destinationDir, "id_rsa_test")
 	if err != nil {
-		return KeysForSsh{}, err
+		return KeysForSSH{}, err
 	}
 
 	privateKeyFileName := temp_file.Name()
@@ -44,21 +44,21 @@ func GenerateKeysForSsh(destinationDir string, cloudUser string) (KeysForSsh, er
 
 	output, exec_cmd_err := exec.Command("bash", "-c", cmd).Output()
 	if exec_cmd_err != nil {
-		return KeysForSsh{}, exec_cmd_err
+		return KeysForSSH{}, exec_cmd_err
 	}
 	fmt.Println(output)
 
 	publicKeyAbsPath, err := filepath.Abs(privateKeyFileName + ".pub")
 	if err != nil {
-		return KeysForSsh{}, err
+		return KeysForSSH{}, err
 	}
 
 	privateKeyAbsPath, err := filepath.Abs(privateKeyFileName)
 	if err != nil {
-		return KeysForSsh{}, err
+		return KeysForSSH{}, err
 	}
 
-	return KeysForSsh{
+	return KeysForSSH{
 		CloudUser:        cloudUser,
 		PublicKeyAbsPath: publicKeyAbsPath,
 		PrivKeyAbsPath:   privateKeyAbsPath,
@@ -71,7 +71,7 @@ type KeysAndInit struct {
 	CloudUser     string
 }
 
-func GenerateKeyPairAndCloudInit(destinationDir string, cloudUser string) (KeysAndInit, error) {
+func GenerateKeyPairAndCloudInit(destinationDir, cloudUser string) (KeysAndInit, error) {
 	fmt.Printf("Generating keypair & cloud-init for user: %s", cloudUser)
 
 	temp_file, err := os.CreateTemp(destinationDir, "id_rsa_test")
@@ -153,76 +153,48 @@ func PublicKeyFile(file string) ssh.AuthMethod {
 	return ssh.PublicKeys(key)
 }
 
-func Run(hostname string, username string, privateKey string, command string) (string, error) {
-	// envVars map[string]string) string {
-	// Establish an SSH connection to the remote server
-	// key1, err := ssh.ParsePrivateKey([]byte(privateKey))
+// newSSHClient dials an SSH connection using private-key authentication.
+// FIXME: host key verification is not yet implemented; connections are
+// currently vulnerable to MITM. See https://stackoverflow.com/a/63308243
+func newSSHClient(hostname, username, privateKey string) (*ssh.Client, error) {
 	keyBytes, err := os.ReadFile(privateKey)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	signer, err := ssh.ParsePrivateKey(keyBytes)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-
-	sshConfig := &ssh.ClientConfig{
-		User: username,
-		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(signer),
-		},
-		/*
-
-			FIXME: Work on supporting host key verification.
-
-			See: https://stackoverflow.com/a/63308243
-
-		*/
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		// Env: envVars,
-		// env: envVars,
-		Timeout: time.Duration(time.Duration.Seconds(60)),
+	cfg := &ssh.ClientConfig{
+		User:            username,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), //nolint:gosec // known limitation, see FIXME above
+		Timeout:         60 * time.Second,
 	}
+	return ssh.Dial("tcp", net.JoinHostPort(hostname, "22"), cfg)
+}
 
-	client, err := ssh.Dial("tcp", net.JoinHostPort(hostname, "22"), sshConfig)
+func Run(hostname, username, privateKey, command string) (string, error) {
+	client, err := newSSHClient(hostname, username, privateKey)
 	if err != nil {
 		return "", err
 	}
-	// Create a session. It is one session per command.
+	defer client.Close()
+
 	session, err := client.NewSession()
 	if err != nil {
 		return "", err
 	}
 	defer session.Close()
-	var b bytes.Buffer  // import "bytes"
-	session.Stdout = &b // get output
-	// you can also pass what gets input to the stdin, allowing you to pipe
-	// content from client to server
-	//      session.Stdin = bytes.NewBufferString("My input")
 
-	// Finally, run the command
+	var b bytes.Buffer
+	session.Stdout = &b
 	err = session.Run(command)
 	return b.String(), err
 }
 
-func Upload(hostname string, username string, privateKey string, localPath string, remotePath string) error {
-	keyBytes, err := os.ReadFile(privateKey)
-	if err != nil {
-		return err
-	}
-	signer, err := ssh.ParsePrivateKey(keyBytes)
-	if err != nil {
-		return err
-	}
-
-	sshConfig := &ssh.ClientConfig{
-		User:            username,
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         time.Duration(time.Duration.Seconds(60)),
-	}
-
-	client, err := ssh.Dial("tcp", net.JoinHostPort(hostname, "22"), sshConfig)
+func Upload(hostname, username, privateKey, localPath, remotePath string) error {
+	client, err := newSSHClient(hostname, username, privateKey)
 	if err != nil {
 		return err
 	}
@@ -244,30 +216,16 @@ func Upload(hostname string, username string, privateKey string, localPath strin
 	if err != nil {
 		return err
 	}
-	defer remoteFile.Close()
 
-	_, err = io.Copy(remoteFile, localFile)
-	return err
+	if _, err = io.Copy(remoteFile, localFile); err != nil {
+		remoteFile.Close()
+		return err
+	}
+	return remoteFile.Close()
 }
 
-func Download(hostname string, username string, privateKey string, remotePath string, localPath string) error {
-	keyBytes, err := os.ReadFile(privateKey)
-	if err != nil {
-		return err
-	}
-	signer, err := ssh.ParsePrivateKey(keyBytes)
-	if err != nil {
-		return err
-	}
-
-	sshConfig := &ssh.ClientConfig{
-		User:            username,
-		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Timeout:         time.Duration(time.Duration.Seconds(60)),
-	}
-
-	client, err := ssh.Dial("tcp", net.JoinHostPort(hostname, "22"), sshConfig)
+func Download(hostname, username, privateKey, remotePath, localPath string) error {
+	client, err := newSSHClient(hostname, username, privateKey)
 	if err != nil {
 		return err
 	}
@@ -289,8 +247,10 @@ func Download(hostname string, username string, privateKey string, remotePath st
 	if err != nil {
 		return err
 	}
-	defer localFile.Close()
 
-	_, err = io.Copy(localFile, remoteFile)
-	return err
+	if _, err = io.Copy(localFile, remoteFile); err != nil {
+		localFile.Close()
+		return err
+	}
+	return localFile.Close()
 }

--- a/validate_ohpygossh.py
+++ b/validate_ohpygossh.py
@@ -231,9 +231,11 @@ def test_with_multipass():
         print("Python validation starting, for 'test_with_multipass'")
 
         from ohpygossh.gohpygossh import (
+            Download,
             GenerateKeyPairAndCloudInit,
             GenerateShortUUID,
             Run,
+            Upload,
         )
 
         short_id = GenerateShortUUID(4)
@@ -289,7 +291,39 @@ def test_with_multipass():
                 if "Connection success" not in output:
                     raise RuntimeError(f"Unexpected SSH output: {output!r}")
 
-                print(f"Multipass e2e test passed. Output: {output!r}")
+                print(f"Run e2e test passed. Output: {output!r}")
+
+                # SFTP round-trip: upload a file, verify it landed, download it back.
+                unique_marker = GenerateShortUUID(8)
+                upload_content = f"ohpygossh-sftp-test:{unique_marker}\n"
+                local_upload = os.path.join(tmpDir, "upload.txt")
+                remote_path = f"/home/{kai.CloudUser}/uploaded.txt"
+                local_download = os.path.join(tmpDir, "download.txt")
+
+                Path(local_upload).write_text(upload_content)
+
+                Upload(ip, kai.CloudUser, kai.SshKeyPath, local_upload, remote_path)
+                print(f"Upload complete: {local_upload} -> {remote_path}")
+
+                cat_output = Run(
+                    ip, kai.CloudUser, kai.SshKeyPath, f"cat {remote_path}"
+                )
+                if cat_output.strip() != upload_content.strip():
+                    raise RuntimeError(
+                        f"Remote file content mismatch after upload. Got: {cat_output!r}"
+                    )
+                print("Remote file content verified via Run/cat.")
+
+                Download(ip, kai.CloudUser, kai.SshKeyPath, remote_path, local_download)
+                print(f"Download complete: {remote_path} -> {local_download}")
+
+                downloaded_content = Path(local_download).read_text()
+                if downloaded_content != upload_content:
+                    raise RuntimeError(
+                        f"Downloaded content does not match original. Got: {downloaded_content!r}"
+                    )
+
+                print(f"SFTP round-trip e2e test passed. Marker: {unique_marker!r}")
 
             finally:
                 print(f"Deleting multipass VM: {vm_name}")

--- a/validate_ohpygossh.py
+++ b/validate_ohpygossh.py
@@ -12,6 +12,7 @@ from os import listdir, chdir
 from os.path import join
 import subprocess
 import tempfile
+import time
 from shlex import split
 
 GIT_ROOT = Path(__file__).parent.resolve()
@@ -249,24 +250,31 @@ def test_with_multipass():
 
             print(f"Launching multipass VM: {vm_name}")
             try:
-                subprocess.run(
-                    [
-                        *mp,
-                        "launch",
-                        "lts",
-                        "--name",
-                        vm_name,
-                        "--cpus",
-                        "1",
-                        "--memory",
-                        "1G",
-                        "--disk",
-                        "5G",
-                        "--cloud-init",
-                        kai.CloudInitPath,
-                    ],
-                    check=True,
-                )
+                launch_cmd = [
+                    *mp,
+                    "launch",
+                    "lts",
+                    "--name",
+                    vm_name,
+                    "--cpus",
+                    "1",
+                    "--memory",
+                    "1G",
+                    "--disk",
+                    "5G",
+                    "--cloud-init",
+                    kai.CloudInitPath,
+                ]
+                for attempt, wait in enumerate([0, 10, 30, 90]):
+                    if wait:
+                        print(
+                            f"Launch attempt {attempt} failed, retrying in {wait}s..."
+                        )
+                        time.sleep(wait)
+                    if subprocess.run(launch_cmd).returncode == 0:
+                        break
+                else:
+                    raise RuntimeError("multipass launch failed after 4 attempts")
 
                 info_result = subprocess.run(
                     [*mp, "info", "--format", "json", vm_name],

--- a/validate_ohpygossh.py
+++ b/validate_ohpygossh.py
@@ -70,11 +70,11 @@ def test_with_keys_only():
     try:
         print("Python validation starting, for 'test_with_keys_only'")
 
-        from ohpygossh.gohpygossh import GenerateKeysForSsh, KeysForSsh
+        from ohpygossh.gohpygossh import GenerateKeysForSSH, KeysForSSH
 
         with tempfile.TemporaryDirectory() as tmpDir:
             print("'ohpygossh': Generating SSH key pair")
-            keys: KeysForSsh = GenerateKeysForSsh(tmpDir, keys_only_user)
+            keys: KeysForSSH = GenerateKeysForSSH(tmpDir, keys_only_user)
 
             print(
                 f"""

--- a/validate_ohpygossh.py
+++ b/validate_ohpygossh.py
@@ -239,7 +239,7 @@ def test_with_multipass():
         )
 
         short_id = GenerateShortUUID(4)
-        vm_name = f"ohpytest-{short_id}".lower()
+        vm_name = f"ohpytest-{short_id}".lower().replace("_", "-")
         mp = _multipass_cmd()
 
         # multipass snap AppArmor profile allows @{HOME}/** but not /tmp/**;


### PR DESCRIPTION
* Adds Upload and Download to the public API using [github.com/pkg/sftp](https://github.com/pkg/sftp). 
* Updates `test_with_multipass` to verify a full round-trip: upload a file with a unique marker, confirm it landed via Run/cat, download it to a different local path, and assert byte-equality with the original.
* Fix / replace '_' with '-' in VM names in both validate_ohpygossh.py and gohpygossh_test.go. Also rename dyn_vm_name to dynVMName (revive) and wrap the Delete defer to satisfy errcheck
* Enhance go linting (`golangci-lint` configuration)