### PR TITLE
fix: sync pyproject.toml to 0.2.0, fix extra-files

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,9 +7,6 @@
       "release-type": "simple",
       "package-name": "ohpygossh",
       "extra-files": [
-        "setup.py",
-        "setup_ci.py",
-        "README.md",
         "pyproject.toml"
       ]
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "gohpygossh"
 # Should match 'setup.py' version number (used for gopy/pybindgen)
-version = "0.0.16"
+version = "0.2.0"
 description = ""
 authors = ["b-long <b-long@users.noreply.github.com>"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ Based on:
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
+version = (this_directory / "version.txt").read_text().strip()
 PACKAGE_PATH = "gohpygossh"
 PACKAGE_NAME = "ohpygossh"
 
@@ -25,8 +26,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/b-long/ohpygossh",
     package_data={PACKAGE_NAME: ["*.so"]},
-    # Should match 'pyproject.toml' version number
-    version="0.0.16",
+    version=version,
     author_email="b-long@users.noreply.github.com",
     include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ Based on:
 
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
-version = (this_directory / "version.txt").read_text().strip()
+version = (this_directory / "version.txt").read_text(encoding="utf-8").strip()
 PACKAGE_PATH = "gohpygossh"
 PACKAGE_NAME = "ohpygossh"
 


### PR DESCRIPTION
   - `pyproject.toml` and `setup.py` were stuck at `0.0.16`, out of sync with the release-please manifest (`0.2.0`). Release-please cannot update a file unless it can find the current version string to replace.
   - `setup.py` now reads from `version.txt` (consistent with `setup_ci.py`), so it stays in sync automatically without needing release-please to manage it.
   - `extra-files` in `.release-please-config.json` trimmed to just `pyproject.toml`: `setup_ci.py` and `setup.py` no longer have a hardcoded version string, and `README.md` no longer contains a version number.
