### PR TITLE
feat: support testing with LXD

### DIFF
--- a/.github/workflows/e2e-lxc.yaml
+++ b/.github/workflows/e2e-lxc.yaml
@@ -1,5 +1,5 @@
 ---
-name: E2E -- Multipass
+name: E2E -- LXC
 
 on:
   push:
@@ -10,8 +10,8 @@ on:
       - main
 
 jobs:
-  e2e-linux:
-    name: E2E Ubuntu (multipass)
+  e2e-lxc:
+    name: E2E Ubuntu (lxc)
     runs-on: ubuntu-22.04
 
     steps:
@@ -28,7 +28,7 @@ jobs:
           cp setup_ci.py setup.py
 
       - name: Build wheel
-        uses: pypa/cibuildwheel@v4.1.0
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_BUILD: "cp311-*_x86_64"
           CIBW_SKIP: "*-musllinux_x86_64"
@@ -42,17 +42,20 @@ jobs:
             go install golang.org/x/tools/cmd/goimports@latest
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Install multipass
-        run: |
-          sudo snap install multipass
-          sudo multipass version
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v1
+        with:
+          channel: latest/edge
+
+      - name: Allow LXD bridge traffic
+        run: sudo iptables -P FORWARD ACCEPT
 
       - name: Install wheel
         run: pip install wheelhouse/*.whl
 
       - name: Run e2e tests
-        run: python3 validate_ohpygossh.py --only=multipass
+        run: python3 validate_ohpygossh.py --only=lxc

--- a/.github/workflows/e2e-lxc.yaml
+++ b/.github/workflows/e2e-lxc.yaml
@@ -28,7 +28,7 @@ jobs:
           cp setup_ci.py setup.py
 
       - name: Build wheel
-        uses: pypa/cibuildwheel@v3.4.1
+        uses: pypa/cibuildwheel@v4.1.0
         env:
           CIBW_BUILD: "cp311-*_x86_64"
           CIBW_SKIP: "*-musllinux_x86_64"
@@ -42,7 +42,7 @@ jobs:
             go install golang.org/x/tools/cmd/goimports@latest
 
       - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/e2e-multipass.yaml
+++ b/.github/workflows/e2e-multipass.yaml
@@ -49,7 +49,17 @@ jobs:
       - name: Install multipass
         run: |
           sudo snap install multipass
-          sudo multipass version
+          # multipassd can take a few seconds to finish initializing after
+          # snap install (e.g. writing its root cert); retry until ready.
+          for i in $(seq 1 10); do
+            if sudo multipass version; then
+              exit 0
+            fi
+            echo "multipassd not ready yet, retrying in 3s... ($i/10)"
+            sleep 3
+          done
+          echo "multipassd did not become ready in time" >&2
+          exit 1
 
       - name: Install wheel
         run: pip install wheelhouse/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+__pycache__/
 .venv/
 dist/
 build/

--- a/validate_ohpygossh.py
+++ b/validate_ohpygossh.py
@@ -224,7 +224,10 @@ def _lxc_cmd() -> list:
 
         try:
             lxd_gid = grp.getgrnam("lxd").gr_gid
-            if lxd_gid not in os.getgroups():
+            if lxd_gid not in os.getgroups() and lxd_gid not in (
+                os.getgid(),
+                os.getegid(),
+            ):
                 return ["sudo", "lxc"]
         except KeyError:
             return ["sudo", "lxc"]
@@ -419,6 +422,49 @@ def test_with_lxc():
                 else:
                     raise RuntimeError("lxc launch failed after 4 attempts")
 
+                # Poll for a routable IPv4 address via lxc list JSON first. This
+                # queries LXD's own state without exec'ing into the container, so
+                # it works even when the in-container shell is not yet ready and
+                # is more robust than running `lxc exec` immediately after start.
+                ip = None
+                for attempt in range(24):
+                    try:
+                        list_result = subprocess.run(
+                            [*lxc, "list", vm_name, "--format", "json"],
+                            capture_output=True,
+                            text=True,
+                            timeout=10,
+                            check=True,
+                        )
+                        containers = json.loads(list_result.stdout or "[]")
+                        for container in containers:
+                            if container.get("name") != vm_name:
+                                continue
+                            network = (container.get("state") or {}).get(
+                                "network"
+                            ) or {}
+                            for _iface, info in network.items():
+                                for addr in (info or {}).get("addresses", []):
+                                    if (
+                                        addr.get("family") == "inet"
+                                        and addr.get("scope") == "global"
+                                    ):
+                                        ip = addr.get("address")
+                        if ip:
+                            break
+                    except (
+                        subprocess.TimeoutExpired,
+                        subprocess.CalledProcessError,
+                        json.JSONDecodeError,
+                    ):
+                        pass
+                    print(f"Waiting for IP address (attempt {attempt + 1}/24)...")
+                    time.sleep(5)
+
+                if not ip:
+                    raise RuntimeError(f"No IPv4 address found for container {vm_name}")
+                print(f"Container IP: {ip}")
+
                 # Wait for cloud-init to finish provisioning the user and SSH keys.
                 # Exit 0 = success; 1 = ran but some modules errored (SSH keys may
                 # still be provisioned); 2 = cloud-init disabled.  All three are
@@ -436,41 +482,6 @@ def test_with_lxc():
                         f"cloud-init status returned unexpected exit code "
                         f"{ci_result.returncode}"
                     )
-
-                # Poll for a routable IPv4 address via lxc list JSON.  This
-                # queries LXD's own state without exec'ing into the container,
-                # so it works even when the in-container shell is not yet ready.
-                ip = None
-                for attempt in range(24):
-                    try:
-                        list_result = subprocess.run(
-                            [*lxc, "list", vm_name, "--format", "json"],
-                            capture_output=True,
-                            text=True,
-                            timeout=10,
-                        )
-                        containers = json.loads(list_result.stdout or "[]")
-                        for container in containers:
-                            network = (container.get("state") or {}).get(
-                                "network"
-                            ) or {}
-                            for _iface, info in network.items():
-                                for addr in info.get("addresses", []):
-                                    if (
-                                        addr["family"] == "inet"
-                                        and addr["scope"] == "global"
-                                    ):
-                                        ip = addr["address"]
-                        if ip:
-                            break
-                    except (subprocess.TimeoutExpired, json.JSONDecodeError):
-                        pass
-                    print(f"Waiting for IP address (attempt {attempt + 1}/24)...")
-                    time.sleep(5)
-
-                if not ip:
-                    raise RuntimeError(f"No IPv4 address found for container {vm_name}")
-                print(f"Container IP: {ip}")
 
                 output = Run(
                     ip, kai.CloudUser, kai.SshKeyPath, "echo 'Connection success'"
@@ -515,9 +526,16 @@ def test_with_lxc():
 
             finally:
                 print(f"Deleting LXC container: {vm_name}")
-                subprocess.run([*lxc, "delete", "--force", vm_name], check=False)
+                subprocess.run(
+                    [*lxc, "delete", "--force", vm_name],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                )
 
     except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
         raise RuntimeError(
             "An unexpected error occurred testing ohpygossh with lxc"
         ) from e

--- a/validate_ohpygossh.py
+++ b/validate_ohpygossh.py
@@ -218,20 +218,63 @@ def _multipass_cmd() -> list:
 
 
 def _lxc_cmd() -> list:
-    """Prefix lxc with sudo if the current user is not in the lxd group."""
-    if sys.platform == "linux" and os.geteuid() != 0 and which("sudo"):
-        import grp
+    """Prefix lxc with sudo if the LXD unix socket isn't accessible as-is.
 
-        try:
-            lxd_gid = grp.getgrnam("lxd").gr_gid
-            if lxd_gid not in os.getgroups() and lxd_gid not in (
-                os.getgid(),
-                os.getegid(),
-            ):
-                return ["sudo", "lxc"]
-        except KeyError:
+    The socket's group is configurable (e.g. canonical/setup-lxd defaults to
+    "adm", not "lxd"), so checking group membership by name is unreliable;
+    probing the actual command is the only check that matches reality.
+    """
+    if sys.platform == "linux" and os.geteuid() != 0 and which("sudo"):
+        if (
+            subprocess.run(
+                ["lxc", "list"], capture_output=True, timeout=10
+            ).returncode
+            != 0
+        ):
             return ["sudo", "lxc"]
     return ["lxc"]
+
+
+def _verify_ssh_and_sftp(ip: str, kai, tmp_dir: str) -> None:
+    """Run the SSH connectivity check and SFTP upload/download round-trip."""
+    from ohpygossh.gohpygossh import Download, GenerateShortUUID, Run, Upload
+
+    output = Run(ip, kai.CloudUser, kai.SshKeyPath, "echo 'Connection success'")
+
+    if "Connection success" not in output:
+        raise RuntimeError(f"Unexpected SSH output: {output!r}")
+
+    print(f"Run e2e test passed. Output: {output!r}")
+
+    # SFTP round-trip: upload a file, verify it landed, download it back.
+    unique_marker = GenerateShortUUID(8)
+    upload_content = f"ohpygossh-sftp-test:{unique_marker}\n"
+    local_upload = os.path.join(tmp_dir, "upload.txt")
+    remote_path = f"/home/{kai.CloudUser}/uploaded.txt"
+    local_download = os.path.join(tmp_dir, "download.txt")
+
+    Path(local_upload).write_text(upload_content)
+
+    Upload(ip, kai.CloudUser, kai.SshKeyPath, local_upload, remote_path)
+    print(f"Upload complete: {local_upload} -> {remote_path}")
+
+    cat_output = Run(ip, kai.CloudUser, kai.SshKeyPath, f"cat {remote_path}")
+    if cat_output.strip() != upload_content.strip():
+        raise RuntimeError(
+            f"Remote file content mismatch after upload. Got: {cat_output!r}"
+        )
+    print("Remote file content verified via Run/cat.")
+
+    Download(ip, kai.CloudUser, kai.SshKeyPath, remote_path, local_download)
+    print(f"Download complete: {remote_path} -> {local_download}")
+
+    downloaded_content = Path(local_download).read_text()
+    if downloaded_content != upload_content:
+        raise RuntimeError(
+            f"Downloaded content does not match original. Got: {downloaded_content!r}"
+        )
+
+    print(f"SFTP round-trip e2e test passed. Marker: {unique_marker!r}")
 
 
 def test_with_multipass():
@@ -243,12 +286,8 @@ def test_with_multipass():
         print("Python validation starting, for 'test_with_multipass'")
 
         from ohpygossh.gohpygossh import (
-            Download,
             GenerateKeyPairAndCloudInit,
             GenerateRandomHostname,
-            GenerateShortUUID,
-            Run,
-            Upload,
         )
 
         vm_name = GenerateRandomHostname()
@@ -303,52 +342,15 @@ def test_with_multipass():
                 ip = ipv4_addresses[0]
                 print(f"VM IP: {ip}")
 
-                output = Run(
-                    ip, kai.CloudUser, kai.SshKeyPath, "echo 'Connection success'"
-                )
-
-                if "Connection success" not in output:
-                    raise RuntimeError(f"Unexpected SSH output: {output!r}")
-
-                print(f"Run e2e test passed. Output: {output!r}")
-
-                # SFTP round-trip: upload a file, verify it landed, download it back.
-                unique_marker = GenerateShortUUID(8)
-                upload_content = f"ohpygossh-sftp-test:{unique_marker}\n"
-                local_upload = os.path.join(tmpDir, "upload.txt")
-                remote_path = f"/home/{kai.CloudUser}/uploaded.txt"
-                local_download = os.path.join(tmpDir, "download.txt")
-
-                Path(local_upload).write_text(upload_content)
-
-                Upload(ip, kai.CloudUser, kai.SshKeyPath, local_upload, remote_path)
-                print(f"Upload complete: {local_upload} -> {remote_path}")
-
-                cat_output = Run(
-                    ip, kai.CloudUser, kai.SshKeyPath, f"cat {remote_path}"
-                )
-                if cat_output.strip() != upload_content.strip():
-                    raise RuntimeError(
-                        f"Remote file content mismatch after upload. Got: {cat_output!r}"
-                    )
-                print("Remote file content verified via Run/cat.")
-
-                Download(ip, kai.CloudUser, kai.SshKeyPath, remote_path, local_download)
-                print(f"Download complete: {remote_path} -> {local_download}")
-
-                downloaded_content = Path(local_download).read_text()
-                if downloaded_content != upload_content:
-                    raise RuntimeError(
-                        f"Downloaded content does not match original. Got: {downloaded_content!r}"
-                    )
-
-                print(f"SFTP round-trip e2e test passed. Marker: {unique_marker!r}")
+                _verify_ssh_and_sftp(ip, kai, tmpDir)
 
             finally:
                 print(f"Deleting multipass VM: {vm_name}")
                 subprocess.run([*mp, "delete", "--purge", vm_name], check=False)
 
     except Exception as e:
+        if isinstance(e, RuntimeError):
+            raise
         raise RuntimeError(
             "An unexpected error occurred testing ohpygossh with multipass"
         ) from e
@@ -363,12 +365,8 @@ def test_with_lxc():
         print("Python validation starting, for 'test_with_lxc'")
 
         from ohpygossh.gohpygossh import (
-            Download,
             GenerateKeyPairAndCloudInit,
             GenerateRandomHostname,
-            GenerateShortUUID,
-            Run,
-            Upload,
         )
 
         vm_name = GenerateRandomHostname()
@@ -450,6 +448,9 @@ def test_with_lxc():
                                         and addr.get("scope") == "global"
                                     ):
                                         ip = addr.get("address")
+                                        break
+                                if ip:
+                                    break
                         if ip:
                             break
                     except (
@@ -483,46 +484,7 @@ def test_with_lxc():
                         f"{ci_result.returncode}"
                     )
 
-                output = Run(
-                    ip, kai.CloudUser, kai.SshKeyPath, "echo 'Connection success'"
-                )
-
-                if "Connection success" not in output:
-                    raise RuntimeError(f"Unexpected SSH output: {output!r}")
-
-                print(f"Run e2e test passed. Output: {output!r}")
-
-                # SFTP round-trip: upload a file, verify it landed, download it back.
-                unique_marker = GenerateShortUUID(8)
-                upload_content = f"ohpygossh-sftp-test:{unique_marker}\n"
-                local_upload = os.path.join(tmpDir, "upload.txt")
-                remote_path = f"/home/{kai.CloudUser}/uploaded.txt"
-                local_download = os.path.join(tmpDir, "download.txt")
-
-                Path(local_upload).write_text(upload_content)
-
-                Upload(ip, kai.CloudUser, kai.SshKeyPath, local_upload, remote_path)
-                print(f"Upload complete: {local_upload} -> {remote_path}")
-
-                cat_output = Run(
-                    ip, kai.CloudUser, kai.SshKeyPath, f"cat {remote_path}"
-                )
-                if cat_output.strip() != upload_content.strip():
-                    raise RuntimeError(
-                        f"Remote file content mismatch after upload. Got: {cat_output!r}"
-                    )
-                print("Remote file content verified via Run/cat.")
-
-                Download(ip, kai.CloudUser, kai.SshKeyPath, remote_path, local_download)
-                print(f"Download complete: {remote_path} -> {local_download}")
-
-                downloaded_content = Path(local_download).read_text()
-                if downloaded_content != upload_content:
-                    raise RuntimeError(
-                        f"Downloaded content does not match original. Got: {downloaded_content!r}"
-                    )
-
-                print(f"SFTP round-trip e2e test passed. Marker: {unique_marker!r}")
+                _verify_ssh_and_sftp(ip, kai, tmpDir)
 
             finally:
                 print(f"Deleting LXC container: {vm_name}")

--- a/validate_ohpygossh.py
+++ b/validate_ohpygossh.py
@@ -217,6 +217,20 @@ def _multipass_cmd() -> list:
     return ["multipass"]
 
 
+def _lxc_cmd() -> list:
+    """Prefix lxc with sudo if the current user is not in the lxd group."""
+    if sys.platform == "linux" and os.geteuid() != 0 and which("sudo"):
+        import grp
+
+        try:
+            lxd_gid = grp.getgrnam("lxd").gr_gid
+            if lxd_gid not in os.getgroups():
+                return ["sudo", "lxc"]
+        except KeyError:
+            return ["sudo", "lxc"]
+    return ["lxc"]
+
+
 def test_with_multipass():
     if not which("multipass"):
         print("multipass not installed, skipping test_with_multipass")
@@ -337,12 +351,200 @@ def test_with_multipass():
         ) from e
 
 
+def test_with_lxc():
+    if not which("lxc"):
+        print("lxc not installed, skipping test_with_lxc")
+        return
+
+    try:
+        print("Python validation starting, for 'test_with_lxc'")
+
+        from ohpygossh.gohpygossh import (
+            Download,
+            GenerateKeyPairAndCloudInit,
+            GenerateRandomHostname,
+            GenerateShortUUID,
+            Run,
+            Upload,
+        )
+
+        vm_name = GenerateRandomHostname()
+        lxc = _lxc_cmd()
+
+        with tempfile.TemporaryDirectory(dir=Path.home()) as tmpDir:
+            kai = GenerateKeyPairAndCloudInit(tmpDir, "cloud-user")
+            cloud_init_content = Path(kai.CloudInitPath).read_text()
+
+            # LXD/cloud-init requires the #cloud-config header to recognise the
+            # payload as YAML; the Go generator omits it.
+            if not cloud_init_content.lstrip().startswith("#cloud-config"):
+                cloud_init_content = "#cloud-config\n" + cloud_init_content.lstrip()
+
+            print(f"Launching LXC container: {vm_name}")
+            try:
+                for attempt, wait in enumerate([0, 10, 30, 90]):
+                    if wait:
+                        print(
+                            f"Launch attempt {attempt} failed, retrying in {wait}s..."
+                        )
+                        subprocess.run(
+                            [*lxc, "delete", "--force", vm_name],
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                        )
+                        time.sleep(wait)
+                    # init + config set + start avoids embedding multi-line YAML
+                    # in --config= and uses the modern cloud-init.user-data key.
+                    if (
+                        subprocess.run([*lxc, "init", "ubuntu:lts", vm_name]).returncode
+                        != 0
+                    ):
+                        continue
+                    if (
+                        subprocess.run(
+                            [
+                                *lxc,
+                                "config",
+                                "set",
+                                vm_name,
+                                "cloud-init.user-data",
+                                cloud_init_content,
+                            ]
+                        ).returncode
+                        != 0
+                    ):
+                        continue
+                    if subprocess.run([*lxc, "start", vm_name]).returncode == 0:
+                        break
+                else:
+                    raise RuntimeError("lxc launch failed after 4 attempts")
+
+                # Wait for cloud-init to finish provisioning the user and SSH keys.
+                # Exit 0 = success; 1 = ran but some modules errored (SSH keys may
+                # still be provisioned); 2 = cloud-init disabled.  All three are
+                # acceptable — the SSH test below is the real gate.
+                ci_result = subprocess.run(
+                    [*lxc, "exec", vm_name, "--", "cloud-init", "status", "--wait"],
+                )
+                if ci_result.returncode == 1:
+                    print(
+                        "Warning: cloud-init reported errors (exit 1); "
+                        "continuing to verify SSH connectivity"
+                    )
+                elif ci_result.returncode not in (0, 2):
+                    raise RuntimeError(
+                        f"cloud-init status returned unexpected exit code "
+                        f"{ci_result.returncode}"
+                    )
+
+                # Poll for a routable IPv4 address via lxc list JSON.  This
+                # queries LXD's own state without exec'ing into the container,
+                # so it works even when the in-container shell is not yet ready.
+                ip = None
+                for attempt in range(24):
+                    try:
+                        list_result = subprocess.run(
+                            [*lxc, "list", vm_name, "--format", "json"],
+                            capture_output=True,
+                            text=True,
+                            timeout=10,
+                        )
+                        containers = json.loads(list_result.stdout or "[]")
+                        for container in containers:
+                            network = (container.get("state") or {}).get(
+                                "network"
+                            ) or {}
+                            for _iface, info in network.items():
+                                for addr in info.get("addresses", []):
+                                    if (
+                                        addr["family"] == "inet"
+                                        and addr["scope"] == "global"
+                                    ):
+                                        ip = addr["address"]
+                        if ip:
+                            break
+                    except (subprocess.TimeoutExpired, json.JSONDecodeError):
+                        pass
+                    print(f"Waiting for IP address (attempt {attempt + 1}/24)...")
+                    time.sleep(5)
+
+                if not ip:
+                    raise RuntimeError(f"No IPv4 address found for container {vm_name}")
+                print(f"Container IP: {ip}")
+
+                output = Run(
+                    ip, kai.CloudUser, kai.SshKeyPath, "echo 'Connection success'"
+                )
+
+                if "Connection success" not in output:
+                    raise RuntimeError(f"Unexpected SSH output: {output!r}")
+
+                print(f"Run e2e test passed. Output: {output!r}")
+
+                # SFTP round-trip: upload a file, verify it landed, download it back.
+                unique_marker = GenerateShortUUID(8)
+                upload_content = f"ohpygossh-sftp-test:{unique_marker}\n"
+                local_upload = os.path.join(tmpDir, "upload.txt")
+                remote_path = f"/home/{kai.CloudUser}/uploaded.txt"
+                local_download = os.path.join(tmpDir, "download.txt")
+
+                Path(local_upload).write_text(upload_content)
+
+                Upload(ip, kai.CloudUser, kai.SshKeyPath, local_upload, remote_path)
+                print(f"Upload complete: {local_upload} -> {remote_path}")
+
+                cat_output = Run(
+                    ip, kai.CloudUser, kai.SshKeyPath, f"cat {remote_path}"
+                )
+                if cat_output.strip() != upload_content.strip():
+                    raise RuntimeError(
+                        f"Remote file content mismatch after upload. Got: {cat_output!r}"
+                    )
+                print("Remote file content verified via Run/cat.")
+
+                Download(ip, kai.CloudUser, kai.SshKeyPath, remote_path, local_download)
+                print(f"Download complete: {remote_path} -> {local_download}")
+
+                downloaded_content = Path(local_download).read_text()
+                if downloaded_content != upload_content:
+                    raise RuntimeError(
+                        f"Downloaded content does not match original. Got: {downloaded_content!r}"
+                    )
+
+                print(f"SFTP round-trip e2e test passed. Marker: {unique_marker!r}")
+
+            finally:
+                print(f"Deleting LXC container: {vm_name}")
+                subprocess.run([*lxc, "delete", "--force", vm_name], check=False)
+
+    except Exception as e:
+        raise RuntimeError(
+            "An unexpected error occurred testing ohpygossh with lxc"
+        ) from e
+
+
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--only",
+        choices=["multipass", "lxc"],
+        help="Run only the named test suite (default: run all)",
+    )
+    args = parser.parse_args()
+    only = args.only
+
     test_say_hello()
 
-    test_with_multipass()
+    if only is None or only == "multipass":
+        test_with_multipass()
 
-    if which("vagrant"):
-        test_with_keys_only()
-    else:
-        print("vagrant not installed, skipping test_with_keys_only")
+    if only is None or only == "lxc":
+        test_with_lxc()
+
+    if only is None:
+        if which("vagrant"):
+            test_with_keys_only()
+        else:
+            print("vagrant not installed, skipping test_with_keys_only")

--- a/validate_ohpygossh.py
+++ b/validate_ohpygossh.py
@@ -226,9 +226,7 @@ def _lxc_cmd() -> list:
     """
     if sys.platform == "linux" and os.geteuid() != 0 and which("sudo"):
         if (
-            subprocess.run(
-                ["lxc", "list"], capture_output=True, timeout=10
-            ).returncode
+            subprocess.run(["lxc", "list"], capture_output=True, timeout=10).returncode
             != 0
         ):
             return ["sudo", "lxc"]


### PR DESCRIPTION
- Fix `_lxc_cmd()` to probe `lxc list` directly instead of checking membership in a hardcoded `lxd` group — `canonical/setup-lxd` configures the daemon socket group as `adm` by default, so the old check was silently wrong (masked by an accidental sudo fallback)
- Fix IP-selection loop in `test_with_lxc` to break on the first matching address instead of silently picking the last one
- Fix `test_with_multipass`'s exception handling to preserve specific `RuntimeError` messages instead of masking them behind a generic error (matching `test_with_lxc`'s existing behavior)
- Extract the duplicated SSH connectivity check + SFTP round-trip logic (~40 lines, byte-identical in both test functions) into a shared `_verify_ssh_and_sftp()` helper
- Pin `e2e-lxc.yaml`'s `cibuildwheel`/`setup-python` versions to match `e2e-multipass.yaml`, removing CI workflow drift
